### PR TITLE
Edge case fixes

### DIFF
--- a/functions/commands.js
+++ b/functions/commands.js
@@ -1,5 +1,4 @@
 const Discord = require('discord.js');
-const {axiosPost} = require('./axiosPost');
 const {axiosGet} = require('./axiosGet');
 const {axiosPatch} = require('./axiosPatch');
 
@@ -47,7 +46,7 @@ module.exports = { commands: async (m, client) => {
                 .setColor("#FFFFFF")
                 .addField(`${process.env.PREFIX}botinfo`, "Displays detailed information about the bot that is currently in use.")
                 .addField(`${process.env.PREFIX}points`, 'Displays the number of points you have acumulated.')
-                .addField(`${process.env.PREFIX}update`, 'Forces the bot to use your current username when refering to you. Please use this if you have recently changed your name recently as the bot has a good memory and bad people skills.')
+                .addField(`${process.env.PREFIX}update`, 'Forces the bot to use your current username when refering to you. Please use this if you have changed your name recently as the bot has a good memory and bad people skills.')
                 .addField(`${process.env.PREFIX}help`, 'Displays this helpful little list of commands for the uninitiated.');
 
             return m.channel.send(botResponse);

--- a/functions/point.js
+++ b/functions/point.js
@@ -4,6 +4,10 @@ const {axiosGet} = require('./axiosGet');
 
 module.exports.point = async (id, giverId) => {
     if (id == giverId) return false;
+    if (giverId == null) {
+        axiosPointPatch(id, { points: 1 })
+        return true
+    }
     let giver = await axiosGet(giverId)
     let recieverPoints = pointCalculator(giver.points)
     axiosPointPatch(id, { points: recieverPoints })

--- a/functions/unPoint.js
+++ b/functions/unPoint.js
@@ -4,6 +4,10 @@ const {axiosGet} = require('./axiosGet');
 
 module.exports.unPoint = async (id, takerId) => {
     if (id == takerId){return false}
+    if (takerId == null) {
+        axiosPointPatch(id, { points: -1 })
+        return true
+    }
     let taker = await axiosGet(takerId);
     let losersPoints = (-1 * pointCalculator(taker.points));
     axiosPointPatch(id, { points: losersPoints })

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
-// require('dotenv').config();
+require('dotenv').config();
 const Discord = require('discord.js');
 const client = new Discord.Client();
 const express = require('express');
 const app = express();
-const {commands} = require("./functions/commands");
-const {userCheck} = require("./functions/userCheck");
-const {point} = require("./functions/point");
-const {unPoint} = require("./functions/unPoint");
+const { commands } = require("./functions/commands");
+const { userCheck } = require("./functions/userCheck");
+const { point } = require("./functions/point");
+const { unPoint } = require("./functions/unPoint");
 
-// fake port listening to ensure that heroku lets the bot be hosted. CAN NOT DEPLOY WITHOUT THIS!
+// Fake port listening to ensure that heroku lets the bot be hosted. CAN NOT DEPLOY WITHOUT THIS!
 app.listen(process.env.PORT);
 
 // Bot fails to opperate before this ready acknowledgement
@@ -29,27 +29,45 @@ client.on('message', (m) => {
     }
 })
 
-// When someone reacts to something, give the person that are reacting to some points
+// When someone reacts to something, give them and the person that they are reacting to some points
 client.on('messageReactionAdd', (reaction, reactor) => {
-    if (reactor.bot||reaction.message.author.bot){return false}
+    // Makes sure the users aren't bots
+    if (reactor.bot || reaction.message.author.bot) { return false }
+    // Makes sure the user hasn't already reacted to this messgae
+    let count = 0
     if (reaction.message.reactions.forEach((r) => {
         r.users.has(reactor.id)
-    })){
-        return false
-    }
+    })) { count += 1 }
+    if (count > 1) { return false }
+    // Checks if the reactor is registered and reigisters them if they are not
+    userCheck(reactor, client);
+    // Checks if the person being reacted to is registered and registers them if they are not
+    userCheck(reaction.message.author, client);
+    // Give the points
+    point(reactor.id, null)
     point(reaction.message.author.id, reactor.id);
+    // Returns for testing purposes
     return true
 })
 
 // When someone unreacts to something, remove points from the person they were reacting to
 client.on('messageReactionRemove', (reaction, reactor) => {
-    if (reactor.bot||reaction.message.author.bot){return false} 
+    // Makes sure the users aren't bots
+    if (reactor.bot || reaction.message.author.bot) { return false }
+    // Makes sure the user hasn't already reacted to this message
     if (reaction.message.reactions.forEach((r) => {
         r.users.has(reactor.id)
-    })){
+    })) {
         return false
     }
+    // Checks if the reactor is registered and reigisters them if they are not
+    userCheck(reactor, client);
+    // Checks if the person being reacted to is registered and registers them if they are not
+    userCheck(reaction.message.author, client);
+    // Take the points
+    unPoint(reactor.id, null)
     unPoint(reaction.message.author.id, reactor.id);
+    // Returns for testing purposes
     return true
 })
 
@@ -69,11 +87,7 @@ client.on('raw', packet => {
         const reaction = message.reactions.get(emoji);
         // Adds the currently reacting user to the reaction's users collection.
         if (reaction) reaction.users.set(packet.d.user_id, client.users.get(packet.d.user_id));
-        // Checks if the reactor is registered and reigisters them if they are not
-        userCheck(client.users.get(packet.d.user_id), client);
-        // Checks if the person being reacted to is registered and registers them if they are not
-        userCheck(message.author, client);
-        // Assign message to reaction
+        // Assign message to reaction to bring them inline with cached reactions 
         reaction.message = message;
         // Check which type of event it is before emitting
         if (packet.t === 'MESSAGE_REACTION_ADD') {

--- a/index.js
+++ b/index.js
@@ -32,14 +32,24 @@ client.on('message', (m) => {
 // When someone reacts to something, give the person that are reacting to some points
 client.on('messageReactionAdd', (reaction, reactor) => {
     if (reactor.bot||reaction.message.author.bot){return false}
-    point(reaction.message.author.id, reactor.id)
+    if (reaction.message.reactions.forEach((r) => {
+        r.users.has(reactor.id)
+    })){
+        return false
+    }
+    point(reaction.message.author.id, reactor.id);
     return true
 })
 
 // When someone unreacts to something, remove points from the person they were reacting to
 client.on('messageReactionRemove', (reaction, reactor) => {
     if (reactor.bot||reaction.message.author.bot){return false} 
-    unPoint(reaction.message.author.id, reactor.id)
+    if (reaction.message.reactions.forEach((r) => {
+        r.users.has(reactor.id)
+    })){
+        return false
+    }
+    unPoint(reaction.message.author.id, reactor.id);
     return true
 })
 
@@ -61,6 +71,8 @@ client.on('raw', packet => {
         if (reaction) reaction.users.set(packet.d.user_id, client.users.get(packet.d.user_id));
         // Checks if the reactor is registered and reigisters them if they are not
         userCheck(client.users.get(packet.d.user_id), client);
+        // Checks if the person being reacted to is registered and registers them if they are not
+        userCheck(message.author, client);
         // Assign message to reaction
         reaction.message = message;
         // Check which type of event it is before emitting


### PR DESCRIPTION
Users no longer get points for multiple reactions from the same person. This fix does not work on uncached messages. Once a message becomes uncached there is no way for the bot to become aware of who has already reacted to it. A possible future fix is to store all necessary data and only rely on discord for event triggers.